### PR TITLE
Rework/execute plsql

### DIFF
--- a/apexPropertiesProvider/provider/parts/businessRuleTask/executePlsql.js
+++ b/apexPropertiesProvider/provider/parts/businessRuleTask/executePlsql.js
@@ -23,26 +23,6 @@ export default function (element, bpmnFactory, commandStack, translate) {
       type === 'executePlsql' ||
       !forbiddenTypes.includes(type))
   ) {
-    // if 'yes' then add 'autoBinds'
-    businessRuleTaskProps.push(
-      entryFactory.selectBox(translate, {
-        id: 'engine',
-        description: translate('Use APEX_EXEC'),
-        modelProperty: 'engine',
-        label: translate('Engine'),
-        selectOptions: [
-          { name: translate('No'), value: 'false' },
-          { name: translate('Yes'), value: 'true' },
-        ],
-        set: function (element, values) {
-          return helper.setExtensionProperty(element, bpmnFactory, values);
-        },
-        get: function (element) {
-          return helper.getExtensionProperty(element, 'engine');
-        },
-      })
-    );
-
     // Run PL/SQL Code
     businessRuleTaskProps.push(
       entryFactory.textBox(translate, {
@@ -82,6 +62,26 @@ export default function (element, bpmnFactory, commandStack, translate) {
       })
     );
 
+    // if 'yes' then add 'autoBinds'
+    businessRuleTaskProps.push(
+      entryFactory.selectBox(translate, {
+        id: 'engine',
+        // description: translate('Use APEX_EXEC'),
+        modelProperty: 'engine',
+        label: translate('Use APEX_EXEC'),
+        selectOptions: [
+          { name: translate('No'), value: 'false' },
+          { name: translate('Yes (deprecated)'), value: 'true' },
+        ],
+        set: function (element, values) {
+          return helper.setExtensionProperty(element, bpmnFactory, values);
+        },
+        get: function (element) {
+          return helper.getExtensionProperty(element, 'engine');
+        },
+      })
+    );
+
     // only shown, when APEX_EXEC is used
     businessRuleTaskProps.push(
       entryFactory.selectBox(translate, {
@@ -93,7 +93,7 @@ export default function (element, bpmnFactory, commandStack, translate) {
         modelProperty: 'autoBinds',
         selectOptions: [
           { name: translate('No'), value: 'false' },
-          { name: translate('Yes'), value: 'true' },
+          { name: translate('Yes (deprecated)'), value: 'true' },
         ],
         hidden: function () {
           return isOptionSelected(businessRuleTaskEngine, engineNo);

--- a/apexPropertiesProvider/provider/parts/scriptTask/executePlsql.js
+++ b/apexPropertiesProvider/provider/parts/scriptTask/executePlsql.js
@@ -23,26 +23,6 @@ export default function (element, bpmnFactory, commandStack, translate) {
       type === 'executePlsql' ||
       !forbiddenTypes.includes(type))
   ) {
-    // if 'yes' then add 'autoBinds'
-    scriptTaskProps.push(
-      entryFactory.selectBox(translate, {
-        id: 'engine',
-        description: translate('Use APEX_EXEC'),
-        modelProperty: 'engine',
-        label: translate('Engine'),
-        selectOptions: [
-          { name: translate('No'), value: 'false' },
-          { name: translate('Yes'), value: 'true' },
-        ],
-        set: function (element, values) {
-          return helper.setExtensionProperty(element, bpmnFactory, values);
-        },
-        get: function (element) {
-          return helper.getExtensionProperty(element, 'engine');
-        },
-      })
-    );
-
     // Run PL/SQL Code
     scriptTaskProps.push(
       entryFactory.textBox(translate, {
@@ -82,6 +62,26 @@ export default function (element, bpmnFactory, commandStack, translate) {
       })
     );
 
+    // if 'yes' then add 'autoBinds'
+    scriptTaskProps.push(
+      entryFactory.selectBox(translate, {
+        id: 'engine',
+        // description: translate('Use APEX_EXEC'),
+        modelProperty: 'engine',
+        label: translate('Use APEX_EXEC'),
+        selectOptions: [
+          { name: translate('No'), value: 'false' },
+          { name: translate('Yes (deprecated)'), value: 'true' },
+        ],
+        set: function (element, values) {
+          return helper.setExtensionProperty(element, bpmnFactory, values);
+        },
+        get: function (element) {
+          return helper.getExtensionProperty(element, 'engine');
+        },
+      })
+    );
+
     // only shown, when APEX_EXEC is used
     scriptTaskProps.push(
       entryFactory.selectBox(translate, {
@@ -93,7 +93,7 @@ export default function (element, bpmnFactory, commandStack, translate) {
         modelProperty: 'autoBinds',
         selectOptions: [
           { name: translate('No'), value: 'false' },
-          { name: translate('Yes'), value: 'true' },
+          { name: translate('Yes (deprecated)'), value: 'true' },
         ],
         hidden: function () {
           return isOptionSelected(scriptTaskEngine, engineNo);

--- a/apexPropertiesProvider/provider/parts/serviceTask/executePlsql.js
+++ b/apexPropertiesProvider/provider/parts/serviceTask/executePlsql.js
@@ -23,26 +23,6 @@ export default function (element, bpmnFactory, commandStack, translate) {
       type === 'executePlsql' ||
       !forbiddenTypes.includes(type))
   ) {
-    // if 'yes' then add 'autoBinds'
-    serviceTaskProps.push(
-      entryFactory.selectBox(translate, {
-        id: 'engine',
-        description: translate('Use APEX_EXEC'),
-        modelProperty: 'engine',
-        label: translate('Engine'),
-        selectOptions: [
-          { name: translate('No'), value: 'false' },
-          { name: translate('Yes'), value: 'true' },
-        ],
-        set: function (element, values) {
-          return helper.setExtensionProperty(element, bpmnFactory, values);
-        },
-        get: function (element) {
-          return helper.getExtensionProperty(element, 'engine');
-        },
-      })
-    );
-
     // Run PL/SQL Code
     serviceTaskProps.push(
       entryFactory.textBox(translate, {
@@ -82,6 +62,26 @@ export default function (element, bpmnFactory, commandStack, translate) {
       })
     );
 
+    // if 'yes' then add 'autoBinds'
+    serviceTaskProps.push(
+      entryFactory.selectBox(translate, {
+        id: 'engine',
+        // description: translate('Use APEX_EXEC'),
+        modelProperty: 'engine',
+        label: translate('Use APEX_EXEC'),
+        selectOptions: [
+          { name: translate('No'), value: 'false' },
+          { name: translate('Yes (deprecated)'), value: 'true' },
+        ],
+        set: function (element, values) {
+          return helper.setExtensionProperty(element, bpmnFactory, values);
+        },
+        get: function (element) {
+          return helper.getExtensionProperty(element, 'engine');
+        },
+      })
+    );
+
     // only shown, when APEX_EXEC is used
     serviceTaskProps.push(
       entryFactory.selectBox(translate, {
@@ -93,7 +93,7 @@ export default function (element, bpmnFactory, commandStack, translate) {
         modelProperty: 'autoBinds',
         selectOptions: [
           { name: translate('No'), value: 'false' },
-          { name: translate('Yes'), value: 'true' },
+          { name: translate('Yes (deprecated)'), value: 'true' },
         ],
         hidden: function () {
           return isOptionSelected(serviceTaskEngine, engineNo);


### PR DESCRIPTION
- Changed executePlsql props order (code field is now first)
- Marked engine option 'use APEX_EXEC' + 'Bind page item values' as deprecated (interferes with restart task mechanism, will be removed in a later release)