### PR TITLE
Fixed asynchronous data

### DIFF
--- a/apexPropertiesProvider/new_provider/parts/callActivity/CallActivityProps.js
+++ b/apexPropertiesProvider/new_provider/parts/callActivity/CallActivityProps.js
@@ -8,33 +8,35 @@ import { getBusinessObject } from '../../helper/util';
 import { DefaultSelectEntry, DefaultSelectEntryAsync, DefaultTextFieldEntry, DefaultToggleSwitchEntry } from '../../helper/templates';
 
 import { useEffect, useState } from '@bpmn-io/properties-panel/preact/hooks';
-
-import {
-  getDiagrams
-} from '../../plugins/metaDataCollector';
+import { getDiagrams } from '../../plugins/metaDataCollector';
 
 export default function (args) {
-  const [diagrams, setDiagrams] = useState([]);
 
   const {element, injector} = args;
 
   const businessObject = getBusinessObject(element);
 
+  const [values, setValues] = useState([]);
+
+  useEffect(() => {
+    if (!values.diagrams) {
+      getDiagrams().then(diagrams => setValues((existing) => { return {...existing, diagrams: diagrams}; }));
+    }
+  }, [element.id]);
+
+  const {diagrams} = values;
+
   const translate = injector.get('translate');
+
+  const entries = [];
 
   const versionSelectionOptions = [
     { label: translate('Latest version'), value: 'latestVersion' },
     { label: translate('Named version'), value: 'namedVersion' },
   ];
 
-  const entries = [];
-
   const manualInput = businessObject.manualInput === 'true';
-  const selection = businessObject.calledDiagramVersionSelection;
-
-  useEffect(() => {
-    getDiagrams().then(diagrams => setDiagrams(diagrams));
-  }, []);
+  const versionSelection = businessObject.calledDiagramVersionSelection;
 
   entries.push(
     {
@@ -95,7 +97,7 @@ export default function (args) {
     }
   );
 
-  if (selection === 'namedVersion') {
+  if (versionSelection === 'namedVersion') {
     entries.push(
       {
         id: 'calledDiagramVersion',

--- a/apexPropertiesProvider/new_provider/parts/userTask/ApexPageProps.js
+++ b/apexPropertiesProvider/new_provider/parts/userTask/ApexPageProps.js
@@ -34,9 +34,6 @@ const listExtensionHelper = new ListExtensionHelper(
 );
 
 export default function (args) {
-  const [applications, setApplications] = useState([]);
-  const [pages, setPages] = useState([]);
-  const [items, setItems] = useState([]);
 
   const {element, injector} = args;
 
@@ -46,22 +43,33 @@ export default function (args) {
 
   const entries = [];
 
-  const applicationId = extensionHelper.getExtensionProperty(element, 'applicationId');
-  const pageId = extensionHelper.getExtensionProperty(element, 'pageId');
-
-  useEffect(() => {
-    getApplications().then(applications => setApplications(applications));
-  }, []);
-
-  useEffect(() => {
-    getPages(applicationId).then(pages => setPages(pages));
-  }, [applicationId]);
-
-  useEffect(() => {
-    getItems(applicationId, pageId).then(items => setItems(items));
-  }, [applicationId, pageId]);
-
   if (!['apexApproval'].includes(businessObject.type)) {
+
+    const [values, setValues] = useState({});
+
+    useEffect(() => {
+      if (!values.applications) {
+        getApplications().then(applications => setValues((existing) => { return {...existing, applications: applications}; }));
+      }
+    }, [element.id]);
+
+    const applicationId = extensionHelper.getExtensionProperty(element, 'applicationId');
+
+    useEffect(() => {
+      if (applicationId) {
+        getPages(applicationId).then(pages => setValues((existing) => { return {...existing, pages: pages}; }));
+      }
+    }, [applicationId]);
+
+    const pageId = extensionHelper.getExtensionProperty(element, 'pageId');
+
+    useEffect(() => {
+      if (applicationId && pageId) {
+        getItems(applicationId, pageId).then(items => setValues((existing) => { return {...existing, items: items}; }));
+      }
+    }, [applicationId, pageId]);
+
+    const {applications, pages, items} = values;
 
     const manualInput = businessObject.manualInput === 'true';
 

--- a/apexPropertiesProvider/new_provider/parts/userTask/ApprovalTaskProps.js
+++ b/apexPropertiesProvider/new_provider/parts/userTask/ApprovalTaskProps.js
@@ -31,8 +31,6 @@ const listExtensionHelper = new ListExtensionHelper(
 );
 
 export default function (args) {
-  const [applications, setApplications] = useState([]);
-  const [tasks, setTasks] = useState([]);
 
   const {element, injector} = args;
 
@@ -44,17 +42,25 @@ export default function (args) {
 
   const entries = [];
 
-  const applicationId = extensionHelper.getExtensionProperty(element, 'applicationId');
-
-  useEffect(() => {
-    getApplications().then(applications => setApplications(applications));
-  }, []);
-
-  useEffect(() => {
-    getTasks(applicationId).then(tasks => setTasks(tasks));
-  }, [applicationId]);
-
   if (businessObject.type === 'apexApproval') {
+
+    const [values, setValues] = useState({});
+
+    useEffect(() => {
+      if (!values.applications) {
+        getApplications().then(applications => setValues((existing) => { return {...existing, applications: applications}; }));
+      }
+    }, [element.id]);
+
+    const applicationId = extensionHelper.getExtensionProperty(element, 'applicationId');
+
+    useEffect(() => {
+      if (applicationId) {
+        getTasks(applicationId).then(tasks => setValues((existing) => { return {...existing, tasks: tasks}; }));
+      }
+    }, [applicationId]);
+
+    const {applications, tasks} = values;
 
     const manualInput = businessObject.manualInput === 'true';
 

--- a/apexPropertiesProvider/new_provider/plugins/metaDataCollector.js
+++ b/apexPropertiesProvider/new_provider/plugins/metaDataCollector.js
@@ -105,8 +105,8 @@ export function getApplicationsMail() {
   console.log('getApplicationsMail');
   return Promise.resolve([
     { label: '', value: null },
-    { label: '1 - A1', value: '1' },
-    { label: '2 - A2', value: '2' },
+    { label: '1 - AM1', value: '1' },
+    { label: '2 - AM2', value: '2' },
   ]); 
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/add-exporter": "^0.2.0",
-        "@bpmn-io/properties-panel": "^1.4.0",
+        "@bpmn-io/properties-panel": "^1.8.0",
         "bpmn-js": "^12.1.0",
         "bpmn-js-bpmnlint": "^0.20.1",
         "bpmn-js-properties-panel": "^1.17.2",
@@ -524,9 +524,9 @@
       "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-1.7.0.tgz",
-      "integrity": "sha512-wffRVDCv8BZ1S2CNwanIsYZ18pXjMitMEuFR217n9lEdMjELopuNxIAcG4ZJ3u5fyHs2/5GZx1tkoPqjtRqtkg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-1.8.0.tgz",
+      "integrity": "sha512-h3nMyJ83Gf4wIAdKsw2+dp+p/9zEN2GvFR+5DQi7q/7vVSH16XOJjkEJrQ95yUjDiBzll++UrGJt9yjwU2ZpuA==",
       "dependencies": {
         "@bpmn-io/feel-editor": "^0.7.0",
         "classnames": "^2.3.1",
@@ -8672,9 +8672,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-1.7.0.tgz",
-      "integrity": "sha512-wffRVDCv8BZ1S2CNwanIsYZ18pXjMitMEuFR217n9lEdMjELopuNxIAcG4ZJ3u5fyHs2/5GZx1tkoPqjtRqtkg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-1.8.0.tgz",
+      "integrity": "sha512-h3nMyJ83Gf4wIAdKsw2+dp+p/9zEN2GvFR+5DQi7q/7vVSH16XOJjkEJrQ95yUjDiBzll++UrGJt9yjwU2ZpuA==",
       "requires": {
         "@bpmn-io/feel-editor": "^0.7.0",
         "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/mt-ag/bpmn-modeler#readme",
   "dependencies": {
     "@bpmn-io/add-exporter": "^0.2.0",
-    "@bpmn-io/properties-panel": "^1.4.0",
+    "@bpmn-io/properties-panel": "^1.8.0",
     "bpmn-js": "^12.1.0",
     "bpmn-js-bpmnlint": "^0.20.1",
     "bpmn-js-properties-panel": "^1.17.2",


### PR DESCRIPTION
Fixed error with state being shared across different groups

- implementation details of the react/preact functionalities offer no clear hint on how the state variables could be shared
- to reduce data traffic and prevent wrong data in the select lists, states are now implemented as object instead of arrays, containing arrays for all the different list types, so if the state still containts the requested value, it does not get overwritten
- results in top-level-data (applications, diagrams, usernames) only gets loaded once on page load, while depending data (pages, items, templates, tasks) still refresh when the according parent changes